### PR TITLE
Jules: Unify docstrings to a consistent style.

### DIFF
--- a/MD_protein_ligand/mutate_pdb.py
+++ b/MD_protein_ligand/mutate_pdb.py
@@ -1,5 +1,4 @@
-"""
-Mutate a residue in a pdb file.
+"""Mutate a residue in a pdb file.
 
 Requires pymol, which can be difficult to install:
 !mamba install -c conda-forge pymol-open-source
@@ -17,17 +16,18 @@ AA_MAP_1_3 = {v:k for k, v in AA_MAP_3_1.items()}
 
 
 def mutate_pdb(pdb_file:str, chains:str, res_num:int, aa:str, check_original_aa:str|None=None, rotamer:str|None=None) -> str:
-    """
-    This function mutates a specific residue in a pdb file and saves the modified structure.
+    """Mutates a specific residue in a PDB file and saves the modified structure.
 
-    Parameters:
-    pdb_file (str): The file path to the input pdb file.
-    chains (str): The chains in the pdb file where the mutation should occur.
-    res_num (int): The residue number where the mutation should occur.
-    aa (str): The new amino acid (in three-letter format) to which the residue should be mutated.
+    Args:
+        pdb_file (str): The file path to the input PDB file.
+        chains (str): The chains in the PDB file where the mutation should occur.
+        res_num (int): The residue number where the mutation should occur.
+        aa (str): The new amino acid (3-letter or 1-letter code) to which the residue should be mutated.
+        check_original_aa (str | None): The original amino acid (3-letter or 1-letter code) to verify before mutation. If None, no check is performed.
+        rotamer (str | None): The specific rotamer to apply. If None, PyMOL's default is used. (Expert use only).
 
     Returns:
-    out_file (str): the mutated pdb file following the format: {pdb_file stem}_{chain}_{residue number}{mutated aa}.pdb
+        out_file (str): The mutated PDB file following the format: {pdb_file stem}_{chain}_{original_aa(s)}{residue_number}{mutated_aa}.pdb
     """
     # important!! otherwise pymol holds onto state
     cmd.reinitialize()

--- a/modal_anarci.py
+++ b/modal_anarci.py
@@ -1,10 +1,11 @@
-"""Run ANARCI
-Antibody Numbering and Antigen Receptor ClassIfication
-https://github.com/oxpig/ANARCI
+"""Runs ANARCI (Antibody Numbering and Antigen Receptor ClassIfication) on Modal.
 
-usage: ANARCI [-h] [--sequence INPUTSEQUENCE] [--outfile OUTFILE] [--scheme {m,c,k,imgt,kabat,chothia,martin,i,a,aho,wolfguy,w}]
-              [--restrict {ig,tr,heavy,light,H,K,L,A,B} [{ig,tr,heavy,light,H,K,L,A,B} ...]] [--csv] [--outfile_hits HITFILE] [--hmmerpath HMMERPATH] [--ncpu NCPU]
-              [--assign_germline] [--use_species {human,mouse,rat,rabbit,rhesus,pig,alpaca,cow}] [--bit_score_threshold BIT_SCORE_THRESHOLD]
+ANARCI Usage:
+  ANARCI [-h] [--sequence INPUTSEQUENCE] [--outfile OUTFILE] [--scheme {m,c,k,imgt,kabat,chothia,martin,i,a,aho,wolfguy,w}]
+                [--restrict {ig,tr,heavy,light,H,K,L,A,B} [{ig,tr,heavy,light,H,K,L,A,B} ...]] [--csv] [--outfile_hits HITFILE] [--hmmerpath HMMERPATH] [--ncpu NCPU]
+                [--assign_germline] [--use_species {human,mouse,rat,rabbit,rhesus,pig,alpaca,cow}] [--bit_score_threshold BIT_SCORE_THRESHOLD]
+
+For more details, see https://github.com/oxpig/ANARCI
 """
 
 from pathlib import Path
@@ -37,6 +38,21 @@ app = App("anarci", image=image)
     mounts=[Mount.from_local_dir(LOCAL_IN, remote_path=REMOTE_IN)],
 )
 def anarci(input_fasta: str, params: str = None) -> list[tuple[str, bytes]]:
+    """Runs ANARCI on a given FASTA file or sequence string using specified parameters.
+
+    Args:
+        input_fasta (str): Path to the input FASTA file (must have .faa or .fasta extension)
+                           or a raw FASTA sequence string. If a path, it's treated as relative
+                           to `LOCAL_IN` if it exists there, otherwise as an absolute path
+                           or direct sequence input within the Modal container.
+        params (str | None): Optional string of additional parameters to pass to the ANARCI
+                             command. If None, defaults to "--csv --ncpu 2".
+
+    Returns:
+        list[tuple[str, bytes]]: A list of tuples, where each tuple contains the output
+                                 filename (str) and its byte content. The filenames are
+                                 derived from the input.
+    """
     Path(REMOTE_OUT).mkdir(parents=True, exist_ok=True)
 
     if (Path(LOCAL_IN) / input_fasta).exists():
@@ -62,6 +78,19 @@ def anarci(input_fasta: str, params: str = None) -> list[tuple[str, bytes]]:
 
 @app.local_entrypoint()
 def main(input_fasta, params=None):
+    """Local entrypoint to run ANARCI via Modal.
+
+    This function takes an input FASTA file (path or string) and optional ANARCI
+    parameters, then calls the remote Modal `anarci` function and saves
+    the results locally.
+
+    Args:
+        input_fasta (str): Path to the input FASTA file or a raw FASTA sequence string.
+        params (str | None): Optional string of additional parameters for ANARCI.
+
+    Returns:
+        None
+    """
     outputs = anarci.remote(input_fasta, params)
 
     for out_file, out_content in outputs:

--- a/modal_bindcraft.py
+++ b/modal_bindcraft.py
@@ -1,5 +1,6 @@
-"""
-adapting
+"""Runs the BindCraft protein binder design pipeline on Modal.
+
+Adapting:
 https://colab.research.google.com/github/martinpacesa/BindCraft/blob/main/notebooks/BindCraft.ipynb
 
 Approximate cost for 3 designs, PDL1.pdb only:
@@ -20,6 +21,14 @@ print(f"Using GPU {GPU}; TIMEOUT {TIMEOUT}")
 
 
 def set_up_pyrosetta():
+    """Installs PyRosetta using pyrosettacolabsetup.
+
+    Args:
+        None
+
+    Returns:
+        None
+    """
     import pyrosettacolabsetup
 
     pyrosettacolabsetup.install_pyrosetta(
@@ -75,6 +84,26 @@ def bindcraft(
     filter_option="Default",
     max_trajectories: int | None = None,
 ):
+    """Executes the BindCraft pipeline to design protein binders against a target structure.
+
+    Args:
+        design_path (str): Path for design outputs within the container.
+        binder_name (str): Name for the binder design project.
+        pdb_str (str): PDB file content as a string.
+        chains (str): Target chain(s) in the PDB.
+        target_hotspot_residues (str): Hotspot residues on the target.
+        lengths (list[int]): Range of lengths for the binder.
+        number_of_final_designs (int): Desired number of final designs.
+        design_protocol (str): Design protocol to use (e.g., "Default", "Beta-sheet").
+        interface_protocol (str): Interface protocol (e.g., "AlphaFold2", "MPNN").
+        template_protocol (str): Template protocol (e.g., "Default", "Masked").
+        filter_option (str): Filter settings to apply (e.g., "Default", "Peptide").
+        max_trajectories (int | None): Maximum number of design trajectories to run.
+
+    Returns:
+        list[tuple[Path, bytes]]: A list of tuples, where each tuple contains the relative output
+                                  file path from `design_path` and its byte content.
+    """
     import json
     import os
     import shutil
@@ -1078,10 +1107,29 @@ def main(
     out_dir: str = "./out/bindcraft",
     run_name: str | None = None,
 ):
-    """
-    target_hotspot_residues: What positions to target in your protein of interest?
-    For example 1,2-10 or chain specific A1-10,B1-20 or entire chains A.
-    If left blank, an appropriate site will be selected by the pipeline.
+    """Local entrypoint to run BindCraft binder design.
+
+    Args:
+        input_pdb (str): Path to the input PDB file.
+        target_chains (str, optional): Target chain(s) in the PDB. Defaults to "A".
+        target_hotspot_residues (str, optional): Hotspot residues on the target.
+            For example "1,2-10" or chain specific "A1-10,B1-20" or entire chains "A".
+            If left blank, an appropriate site will be selected by the pipeline.
+            Defaults to "".
+        lengths (str, optional): Comma-separated string defining the range of lengths for the binder
+                                 (e.g., "50,130"). Defaults to "50,130".
+        number_of_final_designs (int, optional): Desired number of final designs. Defaults to 1.
+        max_trajectories (int | None, optional): Maximum number of design trajectories to run.
+                                                 Defaults to None.
+        binder_name (str | None, optional): Name for the binder design project. If None, it's derived
+                                            from the input PDB filename. Defaults to None.
+        out_dir (str, optional): Directory to save the output files. Defaults to "./out/bindcraft".
+        run_name (str | None, optional): Optional name for the run, used to create a subdirectory
+                                         in `out_dir`. If None, a timestamp-based name is used.
+                                         Defaults to None.
+
+    Returns:
+        None
     """
     from datetime import datetime
 

--- a/modal_chai1.py
+++ b/modal_chai1.py
@@ -1,4 +1,6 @@
-"""Chai-1r https://github.com/chaidiscovery/chai-lab
+"""Runs Chai-1, a protein-ligand co-folding model, on Modal.
+
+Chai-1r: https://github.com/chaidiscovery/chai-lab
 
 Example fasta
 ```
@@ -22,7 +24,14 @@ TIMEOUT = int(os.environ.get("TIMEOUT", 30))
 
 
 def download_models():
-    """Runs Chai-1 on a fasta file and returns the outputs"""
+    """Downloads Chai-1 models by running a minimal inference.
+
+    Args:
+        None
+
+    Returns:
+        None
+    """
     import torch
     from chai_lab.chai1 import run_inference
 
@@ -64,7 +73,23 @@ def chai1(
     use_esm_embeddings: bool = True,
     chai1_kwargs:dict = {},
 ) -> list:
-    """Runs Chai1 on a fasta file and returns the outputs"""
+    """Runs Chai-1 on a FASTA file string and returns the output files.
+
+    Args:
+        input_faa_str (str): Content of the input FASTA file as a string.
+        input_faa_name (str): Original name of the input FASTA file (for naming outputs).
+                              Defaults to "input.faa".
+        num_trunk_recycles (int): Number of trunk recycles for the model. Defaults to 3.
+        num_diffn_timesteps (int): Number of diffusion timesteps. Defaults to 200.
+        seed (int): Random seed for reproducibility. Defaults to 42.
+        use_esm_embeddings (bool): Whether to use ESM embeddings. Defaults to True.
+        chai1_kwargs (dict): Additional keyword arguments to pass to `run_inference`.
+                             Defaults to an empty dict.
+
+    Returns:
+        list[tuple[Path, bytes]]: A list of tuples, where each tuple contains the relative
+                                  output file path and its byte content.
+    """
     import torch
     from chai_lab.chai1 import run_inference
 
@@ -99,6 +124,18 @@ def main(
     run_name: str = None,
     chai1_kwargs: str = None,
 ):
+    """Local entrypoint for running Chai-1 predictions using Modal.
+
+    Args:
+        input_faa (str): Path to the input FASTA file.
+        out_dir (str): Directory to save the output files. Defaults to "./out/chai1".
+        run_name (str | None): Optional name for the run, used in the output directory structure.
+        chai1_kwargs (str | None): Optional string representation of a dictionary for additional
+                                   Chai-1 keyword arguments (e.g., '{"key": "value"}').
+
+    Returns:
+        None
+    """
     from datetime import datetime
 
     input_faa_str = open(input_faa).read()

--- a/modal_diffdock.py
+++ b/modal_diffdock.py
@@ -1,5 +1,6 @@
-"""
-# DiffDock 
+"""Runs DiffDock for molecular docking using a diffusion model on Modal.
+
+# DiffDock
 
 - setting batch_size=1 may help for very large proteins
 
@@ -82,6 +83,22 @@ image = (
     mounts=[Mount.from_local_dir(LOCAL_IN, remote_path=REMOTE_IN)],
 )
 def run_diffdock(pdbs_ligands: list, batch_size: int = 5) -> dict:
+    """Runs DiffDock inference for a list of protein PDB and ligand MOL2 file pairs.
+
+    Args:
+        pdbs_ligands (list[tuple[str, str]]): A list of tuples, where each tuple contains
+                                              the path to a protein PDB file and a ligand MOL2 file.
+                                              Paths should be relative to `LOCAL_IN` if local,
+                                              or absolute within the Modal container.
+        batch_size (int): Batch size for DiffDock inference. Defaults to 5.
+                          Note: Only 1, 5, or 10 have been tested.
+
+    Returns:
+        list[tuple[Path, Path, str, bytes]]: A list of tuples, where each tuple contains
+                                             the input PDB path (as Path object relative to `LOCAL_IN`),
+                                             input ligand path (as Path object relative to `LOCAL_IN`),
+                                             output filename, and its byte content.
+    """
     import os
     from subprocess import run
 
@@ -128,6 +145,19 @@ def main(
     out_dir: str = "./out/diffdock",
     run_name: str = None,
 ):
+    """Local entrypoint to run DiffDock inference for protein-ligand pairs.
+
+    Args:
+        pdb_file (str): Comma-separated string of paths to PDB files.
+        mol2_file (str): Comma-separated string of paths to MOL2 ligand files.
+                         (Order should correspond to `pdb_file`).
+        batch_size (int): Batch size for DiffDock inference. Defaults to 5.
+        out_dir (str): Directory to save the output files. Defaults to "./out/diffdock".
+        run_name (str | None): Optional name for the run, used in the output directory structure.
+
+    Returns:
+        None
+    """
     from datetime import datetime
 
     pdbs_ligands = [


### PR DESCRIPTION
This commit standardizes docstrings across multiple Python files to improve readability and maintainability.

The following steps were taken:
1. I defined a target docstring format:
    - Concise summary line.
    - Blank line after the summary.
    - `Args:` section for parameters (name, type, description).
    - `Returns:` section for return values (type, description).
    - Module-level docstrings summarizing purpose, with existing examples/notes retained.

2. I updated docstrings in the following files to this style:
    - `MD_protein_ligand/mutate_pdb.py`
    - `MD_protein_ligand/simulate.py`
    - `modal_af2rank.py`
    - `modal_alphafold.py`
    - `modal_afdesign.py`
    - `modal_anarci.py`
    - `modal_bindcraft.py`
    - `modal_boltz.py`
    - `modal_chai1.py`
    - `modal_diffdock.py`

This work is part of a larger effort to unify all docstrings in the repository. The remaining files will be addressed in subsequent commits.